### PR TITLE
Add Claude session start hook to install GitHub CLI

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+which gh > /dev/null 2>&1 || sudo apt-get install -y gh

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a Claude project hook that automatically installs the GitHub CLI (`gh`) when starting a session in a remote code environment.

## Key Changes
- Added `.claude/settings.json` configuration file that defines a `SessionStart` hook
- Added `.claude/hooks/session-start.sh` bash script that:
  - Only runs when `CLAUDE_CODE_REMOTE` environment variable is set to `"true"`
  - Checks if the `gh` command is available
  - Installs the GitHub CLI package via `apt-get` if not already present

## Implementation Details
- The hook uses strict bash settings (`set -euo pipefail`) for error handling
- The script gracefully exits early if not running in a remote environment, avoiding unnecessary operations in local development
- Installation uses `sudo` to handle permission requirements for system package installation

https://claude.ai/code/session_01LTuv1fr47mwAxnQqVFnnpH