### PR TITLE
Remove CLAUDE_CODE_REMOTE environment variable check

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
-  exit 0
-fi
-
 which gh > /dev/null 2>&1 || sudo apt-get install -y gh


### PR DESCRIPTION
## Summary
Removed the conditional check for the `CLAUDE_CODE_REMOTE` environment variable in the session start hook, allowing the GitHub CLI installation to run unconditionally.

## Changes
- Removed the `if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then` conditional block that was guarding the `gh` CLI installation
- The GitHub CLI installation now executes every time the session start hook runs, regardless of environment configuration

## Details
Previously, the `gh` CLI installation was only performed when `CLAUDE_CODE_REMOTE` was explicitly set to `"true"`. This change simplifies the hook by removing this environment-based gate, ensuring the GitHub CLI is always available in the session startup process.

https://claude.ai/code/session_01X7gqyniGH8p53WrHMBGEnU