### PR TITLE
Replace gh CLI check with GitHub API token validation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-which gh > /dev/null 2>&1 || sudo apt-get install -y gh
+# GitHub API 접근 가능 여부 확인
+if [ -n "$GH_TOKEN" ]; then
+  curl -s -H "Authorization: token $GH_TOKEN" \
+    https://api.github.com/user > /dev/null 2>&1 \
+    && echo "✅ GitHub API 연결 확인됨" \
+    || echo "⚠️ GitHub API 연결 실패"
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+## GitHub 이슈 작업 방식
+- gh CLI가 없는 환경(모바일 등)에서는
+  curl + $GH_TOKEN으로 GitHub API를 직접 호출
+- 이슈 조회: GET /repos/awesomedays/awesomedays/issues
+- 이슈 생성: POST /repos/awesomedays/awesomedays/issues
+- 이슈 수정: PATCH /repos/awesomedays/awesomedays/issues/{number}
+- 이슈 삭제: DELETE (GraphQL API 사용)


### PR DESCRIPTION
## Summary
Updated the session initialization script to validate GitHub API access using a token-based approach instead of checking for the `gh` CLI tool. This enables GitHub API interactions in environments where the CLI may not be available (e.g., mobile or restricted environments).

## Changes
- **Removed** the `gh` CLI installation check from `session-start.sh`
- **Added** GitHub API connectivity validation using `$GH_TOKEN` environment variable
  - Validates token by making an authenticated request to `/user` endpoint
  - Provides visual feedback with success (✅) or failure (⚠️) indicators
- **Added** `CLAUDE.md` documentation outlining the GitHub API workflow
  - Documents direct API endpoints for issue operations (GET, POST, PATCH, DELETE)
  - Explains the curl + token approach as an alternative to `gh` CLI

## Implementation Details
The new validation uses `curl` with the `GH_TOKEN` header to test API connectivity, making it compatible with environments lacking the GitHub CLI while maintaining the same authentication mechanism. The documentation provides clear guidance on using REST and GraphQL APIs for issue management operations.

https://claude.ai/code/session_01XaxR9NN8bGv11NpYiecVfZ