### PR TITLE
Add GitHub issue CRUD skills and commands for Claude

### DIFF
--- a/.claude/commands/issue-close.md
+++ b/.claude/commands/issue-close.md
@@ -1,0 +1,3 @@
+Use the issue-close skill to close a GitHub issue.
+
+User request: $ARGUMENTS

--- a/.claude/commands/issue-create.md
+++ b/.claude/commands/issue-create.md
@@ -1,0 +1,3 @@
+Use the issue-create skill to create a GitHub issue.
+
+User request: $ARGUMENTS

--- a/.claude/commands/issue-delete.md
+++ b/.claude/commands/issue-delete.md
@@ -1,0 +1,3 @@
+Use the issue-delete skill to permanently delete a GitHub issue.
+
+User request: $ARGUMENTS

--- a/.claude/commands/issue-list.md
+++ b/.claude/commands/issue-list.md
@@ -1,0 +1,3 @@
+Use the issue-list skill to list GitHub issues.
+
+User request: $ARGUMENTS

--- a/.claude/commands/issue-update.md
+++ b/.claude/commands/issue-update.md
@@ -1,0 +1,3 @@
+Use the issue-update skill to update a GitHub issue.
+
+User request: $ARGUMENTS

--- a/.claude/skills/issue-close/SKILL.md
+++ b/.claude/skills/issue-close/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: issue-close
+description: GitHub 이슈를 닫습니다. "이슈 #5 닫아줘", "issue-close 스킬로 완료 처리해줘" 같은 자연어 요청에 반응합니다.
+---
+
+# SKILL: issue-close
+
+공통 설정: `$GH_TOKEN` 환경변수, repo = `awesomedays/awesomedays`
+
+사용자의 요청에서 닫을 이슈 번호를 파악하세요. 번호가 명시되지 않으면 먼저 issue-list로 목록을 보여주고 선택하게 하세요.
+
+아래 curl 명령을 실행하세요:
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: token $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues/{{번호}}" \
+  -d '{"state": "closed"}' \
+  | python3 -c "
+import json, sys
+i = json.load(sys.stdin)
+print(f\"닫힘 #{i['number']}: {i['title']}\")"
+```

--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: issue-create
+description: GitHub 이슈를 생성합니다. "이슈 만들어줘", "issue-create 스킬로 이슈 생성해줘" 같은 자연어 요청에 반응합니다.
+---
+
+# SKILL: issue-create
+
+공통 설정: `$GH_TOKEN` 환경변수, repo = `awesomedays/awesomedays`
+
+사용자의 요청과 대화 맥락을 바탕으로 다음을 스스로 판단하세요:
+- `title`: 핵심 내용을 담은 명확하고 간결한 제목
+- `body`: 배경·목적·세부사항을 포함한 본문 (마크다운 사용 가능)
+- `labels`: 내용에 맞는 레이블 선택 (book-relocation / book-purchase / daily / 기타)
+
+판단한 값으로 아래 curl 명령을 실행하세요:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: token $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues" \
+  -d '{
+    "title": "{{제목}}",
+    "body": "{{본문}}",
+    "labels": ["{{레이블}}"]
+  }' | python3 -c "
+import json, sys
+i = json.load(sys.stdin)
+print(f\"생성완료 #{i['number']}: {i['title']}\")
+print(f\"https://github.com/awesomedays/awesomedays/issues/{i['number']}\")"
+```
+
+실행 전에 판단한 제목·본문·레이블을 사용자에게 먼저 보여주고 확인을 받으세요.

--- a/.claude/skills/issue-delete/SKILL.md
+++ b/.claude/skills/issue-delete/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: issue-delete
+description: GitHub 이슈를 완전히 삭제합니다 (되돌릴 수 없음). "이슈 #5 삭제해줘", "issue-delete 스킬로 지워줘" 같은 자연어 요청에 반응합니다. 삭제 대신 close를 권장하세요.
+---
+
+# SKILL: issue-delete
+
+공통 설정: `$GH_TOKEN` 환경변수, repo = `awesomedays/awesomedays`
+
+⚠️ 삭제는 되돌릴 수 없습니다. 실행 전에 반드시 사용자에게 확인을 받으세요.
+보통은 issue-close로 대체하는 것을 먼저 권유하세요.
+
+사용자가 삭제를 확인하면 아래 두 단계를 순서대로 실행하세요:
+
+```bash
+# 1단계: node_id 조회
+NODE_ID=$(curl -s \
+  -H "Authorization: token $GH_TOKEN" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues/{{번호}}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['node_id'])")
+
+# 2단계: GraphQL로 삭제
+curl -s -X POST \
+  -H "Authorization: token $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/graphql" \
+  -d "{\"query\": \"mutation { deleteIssue(input: {issueId: \\\"$NODE_ID\\\"}) { repository { name } } }\"}" \
+  | python3 -c "
+import json, sys
+r = json.load(sys.stdin)
+print('삭제완료' if 'data' in r else f'오류: {r}')"
+```

--- a/.claude/skills/issue-list/SKILL.md
+++ b/.claude/skills/issue-list/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: issue-list
+description: GitHub 이슈 목록을 조회합니다. "이슈 목록 보여줘", "open 이슈 뭐 있어", "book-purchase 레이블 이슈 알려줘" 같은 자연어 요청에 반응합니다.
+---
+
+# SKILL: issue-list
+
+공통 설정: `$GH_TOKEN` 환경변수, repo = `awesomedays/awesomedays`
+
+사용자의 요청에서 다음 파라미터를 판단하세요:
+- `state`: open(기본값) | closed | all
+- `labels`: 레이블명 (없으면 생략)
+- `per_page`: 결과 수 (기본 30, 최대 100)
+
+아래 curl 명령을 실행하되, 파라미터를 URL 쿼리에 적절히 반영하세요:
+
+```bash
+curl -s \
+  -H "Authorization: token $GH_TOKEN" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues?state=open&per_page=30" \
+  | python3 -c "
+import json, sys
+issues = json.load(sys.stdin)
+if not issues:
+    print('이슈 없음')
+else:
+    for i in issues:
+        labels = ','.join(l['name'] for l in i['labels'])
+        label_str = f'[{labels}]' if labels else ''
+        print(f\"#{i['number']} {label_str} {i['title']}\")"
+```

--- a/.claude/skills/issue-update/SKILL.md
+++ b/.claude/skills/issue-update/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: issue-update
+description: GitHub 이슈를 수정합니다. "이슈 #5 제목 바꿔줘", "issue-update 스킬로 본문 수정해줘" 같은 자연어 요청에 반응합니다.
+---
+
+# SKILL: issue-update
+
+공통 설정: `$GH_TOKEN` 환경변수, repo = `awesomedays/awesomedays`
+
+사용자의 요청에서 다음을 판단하세요:
+- `number`: 수정할 이슈 번호 (필수)
+- 수정할 필드만 선택 (수정하지 않는 필드는 `-d` 본문에서 제외):
+  - `title`: 새 제목
+  - `body`: 새 본문
+  - `state`: open | closed
+  - `labels`: 새 레이블 배열
+
+아래 curl 명령을 실행하세요:
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: token $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues/{{번호}}" \
+  -d '{
+    "title": "{{새제목}}",
+    "body": "{{새본문}}",
+    "labels": ["{{레이블}}"]
+  }' | python3 -c "
+import json, sys
+i = json.load(sys.stdin)
+print(f\"수정완료 #{i['number']}: {i['title']} ({i['state']})\")"
+```
+
+실행 전에 수정 내용을 사용자에게 먼저 보여주고 확인을 받으세요.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,110 @@
+# SKILL.md - GitHub 이슈 CRUD 루틴
+
+공통 설정: `$GH_TOKEN` 환경변수, repo = `awesomedays/awesomedays`
+
+---
+
+## SKILL: issue-list (이슈 목록 조회)
+
+```bash
+curl -s \
+  -H "Authorization: token $GH_TOKEN" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues?state=open&per_page=30" \
+  | python3 -c "
+import json, sys
+issues = json.load(sys.stdin)
+for i in issues:
+    print(f\"#{i['number']} [{','.join(l['name'] for l in i['labels'])}] {i['title']}\")"
+```
+
+옵션 파라미터 (URL 쿼리에 추가):
+- `state=open|closed|all`
+- `labels=레이블명`
+- `per_page=N` (최대 100)
+
+---
+
+## SKILL: issue-create (이슈 생성)
+
+```bash
+curl -s -X POST \
+  -H "Authorization: token $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues" \
+  -d '{
+    "title": "{{제목}}",
+    "body": "{{본문}}",
+    "labels": ["{{레이블}}"]
+  }' | python3 -c "import json,sys; i=json.load(sys.stdin); print(f\"생성완료 #{i['number']}: {i['title']}\nhttps://github.com/awesomedays/awesomedays/issues/{i['number']}\")"
+```
+
+레이블 옵션 (현재 저장소 기준):
+- `book-relocation` / `book-purchase` / `daily` 등 기존 이슈 참고
+
+---
+
+## SKILL: issue-update (이슈 수정)
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: token $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues/{{번호}}" \
+  -d '{
+    "title": "{{새제목}}",
+    "body": "{{새본문}}",
+    "state": "open|closed",
+    "labels": ["{{레이블}}"]
+  }' | python3 -c "import json,sys; i=json.load(sys.stdin); print(f\"수정완료 #{i['number']}: {i['title']} ({i['state']})\")"
+```
+
+수정하지 않을 필드는 `-d` 본문에서 제외하면 됩니다.
+
+---
+
+## SKILL: issue-close (이슈 닫기)
+
+issue-update의 단축형:
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: token $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues/{{번호}}" \
+  -d '{"state": "closed"}' \
+  | python3 -c "import json,sys; i=json.load(sys.stdin); print(f\"닫힘 #{i['number']}: {i['title']}\")"
+```
+
+---
+
+## SKILL: issue-delete (이슈 삭제)
+
+REST API는 삭제 미지원 → GraphQL 사용:
+
+```bash
+# 1단계: 이슈의 node_id 조회
+NODE_ID=$(curl -s \
+  -H "Authorization: token $GH_TOKEN" \
+  "https://api.github.com/repos/awesomedays/awesomedays/issues/{{번호}}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['node_id'])")
+
+# 2단계: GraphQL로 삭제
+curl -s -X POST \
+  -H "Authorization: token $GH_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/graphql" \
+  -d "{\"query\": \"mutation { deleteIssue(input: {issueId: \\\"$NODE_ID\\\"}) { repository { name } } }\"}" \
+  | python3 -c "import json,sys; r=json.load(sys.stdin); print('삭제완료' if 'data' in r else f'오류: {r}')"
+```
+
+주의: 삭제는 되돌릴 수 없습니다. 보통 close로 대체 권장.
+
+---
+
+## 사용 가이드
+
+이 스킬들을 활용할 때 다음과 같이 요청하면 됩니다:
+
+> "issue-create 스킬로 이슈 만들어줘: 제목은 ..., 본문은 ..., 레이블은 ..."
+> "issue-list 스킬로 open 이슈 보여줘"
+> "issue-close 스킬로 #5 닫아줘"


### PR DESCRIPTION
## Summary
This PR adds a comprehensive set of GitHub issue management skills and commands that enable Claude to perform CRUD operations on GitHub issues for the `awesomedays/awesomedays` repository.

## Key Changes

### Skills Added
- **issue-list**: Query and display GitHub issues with filtering by state, labels, and pagination
- **issue-create**: Create new GitHub issues with title, body, and labels
- **issue-update**: Modify existing issues (title, body, state, labels)
- **issue-close**: Close issues (shorthand for state update)
- **issue-delete**: Permanently delete issues using GraphQL API (with safety warnings)

### Commands Added
- Five command files (`.claude/commands/`) that map user requests to corresponding skills:
  - `issue-list.md`
  - `issue-create.md`
  - `issue-update.md`
  - `issue-close.md`
  - `issue-delete.md`

### Documentation
- **SKILL.md**: Comprehensive reference guide with all five skills, usage examples, and guidelines
- **Individual skill files** (`.claude/skills/*/SKILL.md`): Detailed documentation for each skill including:
  - Metadata (name, description)
  - Parameter guidance
  - curl command templates
  - Pre-execution confirmation requirements

## Notable Implementation Details

- All skills use GitHub REST API v3 with token-based authentication via `$GH_TOKEN` environment variable
- Issue deletion uses GraphQL API (REST API doesn't support deletion) with a two-step process
- Skills include user-friendly output formatting with Python JSON parsing
- Safety measures implemented: deletion requires explicit confirmation, close is recommended over delete
- Skills intelligently parse user requests to determine parameters (state, labels, per_page, etc.)
- Pre-execution confirmation is required for create, update, and delete operations

https://claude.ai/code/session_01TxRdaExRWAndFsdNPjdLro